### PR TITLE
Translated README.md to spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ﻿# CovidTracer
 
+![Click aqui para leer la version en ESPAÑOL](README_ESP.md)
+
 CovidTracer is a heavily **decentralized** and **anonymous** contact tracing application designed for the ongoing COVID-19 pandemic.
 
 CovidTracer notifies users of any close contact with other users diagnosed with COVID-19. 

--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ These users provided the translation in the following languages:
 - Croatian/Hrvatski: [micimacahaca](https://old.reddit.com/user/micimacahaca);
 - Dutch: [vlammuh](https://www.reddit.com/user/vlammuh) and [bavoceulemans](https://github.com/bavoceulemans);
 - Brazilian/Portuguese: [Raphael Salomao](https://github.com/raphaelsalomao3);
-- Spanish: [Barraguesh](https://github.com/Barraguesh).
+- Spanish: [Barraguesh](https://github.com/Barraguesh) and [PinkDev1](https://github.com/PinkDev1).

--- a/README_ESP.md
+++ b/README_ESP.md
@@ -70,25 +70,25 @@ El identificador actual enviado por bluetooth [es derivado](CovidTracer/Models/K
 
     CurrentKey = TRUNCATE(HMAC-SHA256(DailyKey, CurrentTime('YYYY-MM-DDTHH'))
 
-If a user reports her/himself positive to SARS-CoV-2, all the generated daily identifiers used/to be used during the infectious period will be [shared with a central server](https://covid-tracer-backend.herokuapp.com/cases.json) (from 5 days before the symptoms onset, up to 11 days after). Other application instances can then derivate all hourly generated keys during the infectious period, and potentially match then with any contacto they previously had. 
+Si un usuario se reporta a si mismo como positivo para SARS-CoV-2, todos los identificadores diarios usados/a ser usados durante el periodo infeccioso van a ser [compartidos con un servidor central](https://covid-tracer-backend.herokuapp.com/cases.json) (desde 5 dias antes de que aparescan los simtomas, hasta 11 dias despues). Otras instancias de la aplicacion pueden despues derivar llaves generadas horalmente durante el periodo infeccioso, y potencialmente coincidir con cualquier contacto que allan tenido previamente. 
 
-Additional measures have been taken to increase privacy:
+Medidas adicionales para mejorar la privacidad:
 
-- contacto tracing keys are automatically removed from the phone after 15 days;
-- The backend returns daily keys in alphabetical order, and only publishes them every 12 hours. This makes it harder to associate multiple daily keys with a single user;
-- The backend does not publish daily keys of future dates, and the apps only match contacts that occured on the day associated with the key. This prevents user impersonification; 
-- Bluetooth signal quality is used to evaluate proximity of nearby devices. The algorithm is calibrated to only record identifiers of devices located in the same room;
-- The backend implements strict rate-limiting on reporting;
-- All communication with the backend is done over HTTPS;
-- The backend [is availaible](https://github.com/RaphaelJ/covid-tracer-backend) as a free and opensource software.
+- Las llaves de rastreo de contactos son automaticamente removidas del dispositivo luego de 15 dias;
+- El backend retorna llaves diarias en orden alfabetico, y solo las publica cada 12 horas. Esto hace que sea mas dificil asociar multiples llaves diarias con un solo usuario;
+- El backend no publica llaves diarias de fechas futuras, y las aplicacionessolo coinciden contactos que ocurrieron en el dia asociado con la llave. Esto evita la impersonificacion del usuario; 
+- La calidad de la señal Bluetooth es usada para evaluar la proximidad de dispositivos cercanos. El algoritmo solo para registrar identificadores de dispositivos ubicados en la misma habitacion;
+- El backend implementa limites de ratio estrictos en el reportaje;
+- Toda la communicacion con el backend se hace mediante HTTPS;
+- El backend [esta disponible](https://github.com/RaphaelJ/covid-tracer-backend) como software libre y gratuito.
 
-More advanced diagnostic and debugging information can be obtained directly in the application by tapping 10 times on the tracer key ID on the *About* page.
+Opciones mas avanzadas de diagnostico e informacion de debugging se puede obtener diractamente desde la aplicacion haciendo click 10 veces en la "tracer key ID" en la pagina de *Acerca de*.
 
-## Special thanks
+## Agradecimientos especiales
 
-These users provided the translation in the following languages:
+Estos usuarios proveyeron la traduccion en los siguientes lenguajes:
 
 - Croatian/Hrvatski: [micimacahaca](https://old.reddit.com/user/micimacahaca);
-- Dutch: [vlammuh](https://www.reddit.com/user/vlammuh) and [bavoceulemans](https://github.com/bavoceulemans);
-- Brazilian/Portuguese: [Raphael Salomao](https://github.com/raphaelsalomao3);
-- Spanish: [Barraguesh](https://github.com/Barraguesh).
+- Holandés: [vlammuh](https://www.reddit.com/user/vlammuh) y [bavoceulemans](https://github.com/bavoceulemans);
+- Brazileño/Portugues: [Raphael Salomao](https://github.com/raphaelsalomao3);
+- Español: [Barraguesh](https://github.com/Barraguesh) y [PinkDev1](https://github.com/PinkDev1)

--- a/README_ESP.md
+++ b/README_ESP.md
@@ -1,92 +1,92 @@
 ﻿# CovidTracer
 
-CovidTracer es una aplicacion de rastreo de contacto **decentralisada** y **anonima** diseñada para la pandema actual del COVID-19.
+CovidTracer es una aplicación de rastreo de contacto **descentralizada** y **anónima** diseñada para la pandemia actual del COVID-19.
 
 CovidTracer le notifica al usuario de cualquier contacto cercano con otros usuarios diagnosticados con COVID-19. 
 
 ![Android](screenshots/screenshot-android.png) ![iOS](screenshots/screenshot-ios.png)
 
-CovidTracer usa Bluetooth y tecnicas criptograficas para proteger la privacidad del usuario. Los usuarios de la app no comparten informacion personal. Jamas se mantiene ningun registro de la ubicacion GPS.
+CovidTracer usa Bluetooth y técnicas criptográficas para proteger la privacidad del usuario. Los usuarios de la app no comparten informacion personal. Jamas se mantiene ningún registro de la ubicación GPS.
 
 CovidTracer sigue las [recomendaciones de rastreo de contacto](https://www.eff.org/deeplinks/2020/04/challenge-proximity-apps-covid-19-contacto-tracing) de la Electronic Frontier Foundation.
 
-CovidTracer is a software libre y gratuito(GPLv3).
+CovidTracer es un software libre y gratuito(GPLv3).
 
-## Descarga e Instalacion
+## Descarga e Instalación
 
-Google y Apple [actualmente no permiten](https://www.theverge.com/2020/3/5/21167102/apple-google-coronavirus-iphone-apps-android-misinformation-reject-ban) ninguna aplicacion relacionada al coronavirus que no este relacionada con organizaciones de la salud reconozidas o gobiernos o sus tiendas. La aplicacion aun se puede instalar por medios alternativos:
+Google y Apple [actualmente no permiten](https://www.theverge.com/2020/3/5/21167102/apple-google-coronavirus-iphone-apps-android-misinformation-reject-ban) ninguna aplicación relacionada al coronavirus que no este relacionada con organizaciones de la salud reconocidas o gobiernos o sus tiendas. La aplicación aun se puede instalar por medios alternativos:
 
 En **Android**, se puede descargar un APK instalable [aqui](https://github.com/RaphaelJ/covid-tracer/releases/download/v0.1.1/covidtracer_0.1.1.apk).
 
-En **iOS**, solo los desarrolladores registrados de Apple pueden compilar, firmar e instalar la app en sus iPhones. Esto se puede realizar mediante la clonacion del repositorio y mediante el uso de [Visual Studio para macOS](https://visualstudio.microsoft.com/vs/mac/). La app de iOS no soporta todas las caracteristicas aun. 
+En **iOS**, solo los desarrolladores registrados de Apple pueden compilar, firmar e instalar la app en sus iPhones. Esto se puede realizar mediante la clonacion del repositorio y mediante el uso de [Visual Studio para macOS](https://visualstudio.microsoft.com/vs/mac/). La app de iOS no soporta todas las características aun. 
 
 ## Preguntas Frecuentes
 
 - **Cuales son las capacidades de privacidad en CovidTracer?**
-CovidTracer usa tecnicas criptograficas similares a las usadas por e-commerce y crypto-monedas. Estas proveen altos niveles de privacidad que evitan que cualquiera asocie el uso de esta app con cualquiera de tus datos personales (ubicacion, nombre...).
+CovidTracer usa tecnicas criptograficas similares a las usadas por e-commerce y crypto-monedas. Estas proveen altos niveles de privacidad que evitan que cualquiera asocie el uso de esta app con cualquiera de tus datos personales (ubicación, nombre...).
 
-- **Cuando deberia usar CovidTracer?**
-Para eficiencia maxima, abre la app y dejala ejecutarse en 2do plano cuando interactuas con personas ajenas a tu hogas (transportes, officina, tiendas, actividades en el exterior...).
+- **Cuando debería usar CovidTracer?**
+Para eficiencia máxima, abre la app y déjala ejecutarse en 2do plano cuando interactúas con personas ajenas a tu hogar (transportes, oficina, tiendas, actividades en el exterior...).
 
-- **Que hago cuando la aplicacion detecta un contacto de alto riesgo?**
-Por favor informa a la autoridad competente tan pronto como se detecte el contacto de alto-riesgo. La app no notifica a ninguna organizacion gubernamental ni de la salud sobre el caso positivo.
+- **Que hago cuando la aplicación detecta un contacto de alto riesgo?**
+Por favor informa a la autoridad competente tan pronto como se detecte el contacto de alto-riesgo. La app no notifica a ninguna organización gubernamental ni de la salud sobre el caso positivo.
 
-- **Por que pide acceso a la ubicacion la aplicacion de Android?**
-La aplicacion de Android debe [pedir el permiso de ubicacion](https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions) para acceder a algunas capacidades bluetooth, como el escaneo. CovidTracer no utiliza ni registra.
+- **Por que pide acceso a la ubicación la aplicación de Android?**
+La aplicación de Android debe [pedir el permiso de ubicacion](https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions) para acceder a algunas capacidades bluetooth, como el escaneo. CovidTracer no utiliza ni registra.
 
-- **Como puedo remover cualquier informacion recolectada por la app?**
-Des-instalar la aplicacion de tu smartphone va a borrar toda la informacion que recolecto la aplicacion. Si alguna vez te reportaste a ti mismo como un caso positivo, algunos datos (anonimos) asociados a tu periodo infeccioso aun van a estar disponibles a otros usuarios de la app.
+- **Como puedo remover cualquier información recolectada por la app?**
+Des-instalar la aplicación de tu smartphone va a borrar toda la informacion que recolecto la aplicacion. Si alguna vez te reportaste a ti mismo como un caso positivo, algunos datos (anónimos) asociados a tu periodo infeccioso aun van a estar disponibles a otros usuarios de la app.
 
 - **Me gusta el proyecto. Como puedo ayudar?** 
-Estoy desarrollando la aplicacion como un proyecto personalcon pocos recorsos. Recibiria con mucho gusto cualquier ayuda.
-    - Si hablas un lenguaje extrangero, puedes ayudar traduciendo [uno de los archivos de localizacion](CovidTracer/Resx/);
-    - Si tienes habilidades en ciencia computacional y/o cryptografia, no dudes en leer los detalles tecnicos y en proveer feedback;
-    - Si eres un diseñador grafico o de UX, puedes ayudar a mejorar algunos de los componentes de la UI de la aplicacion (onboarding, iconos...);
-    - Crear una applicacion (mayormente) distribuida de rastreo de contacto es posible. Por favor presiona a tu gobierno local a tener la privacidad en cuenta si estan desarrollando sus propios sistemas de rastreo de contactos.
+Estoy desarrollando la aplicación como un proyecto personalcon pocos recursos. Recibiría con mucho gusto cualquier ayuda.
+    - Si hablas un lenguaje extranjero, puedes ayudar traduciendo [uno de los archivos de localización](CovidTracer/Resx/);
+    - Si tienes habilidades en ciencia computacional y/o cryptografia, no dudes en leer los detalles técnicos y en proveer feedback;
+    - Si eres un diseñador gráfico o de UX, puedes ayudar a mejorar algunos de los componentes de la UI de la aplicación (onboarding, iconos...);
+    - Crear una aplicación (mayormente) distribuida de rastreo de contacto es posible. Por favor presiona a tu gobierno local a tener la privacidad en cuenta si están desarrollando sus propios sistemas de rastreo de contactos.
 
 ## Detalles tecnicos
 
 ### Overview
 
-The app constantly broadcasts a unique 20 bytes identifier over Bluetooth Low Energy to nearby devices. This identifier is randonly generated (thus can not be associated with personal information) and is renewed every hour (preventing long-term tracking). Nearby CovidTracer users constantly record these identifiers in a database located on their devices. These identifiers are not shared with any central server or entity.
+La app constantemente envía(broadcasts) un identificador de 20 bytes mediante Bluetooth Low Energy (BLE) a dispositivos cercanos. Este identificador se genera aleatoriamente (y por lo tanto no puede ser relacionado con información personal) y es renovado cada hora (evitando el rastreo por largo tiempo). Usuarios cercanos de CovidTracer constantemente registran estos identificadores en una base de datos localizada en sus dispositivos. Estos identificadores no se comparten con ningún servidor central ni entidad.
 
-If the user ever reports her/himself as positive to SARS-CoV-2, the hourly-generated identifiers coresponding to the infectious period (16 days) are anonymously published on a central server. Other app users can then compare these identifiers with the ones they recorded over the past few days.
+Si el usuario alguna vez se reporta a si mismo con positivo para SARS-CoV-2, los identificadores generados horalmente correspondientes al periodo infeccioso (16 días) son anónimamente publicados en un servidor central. Otros usuarios de la app pueden luego comparar estos identificadores con los que registraron en los últimos días.
 
 ### Detalles
 
-Cuando la app se abre por primera vez, se [genera una llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L54) usando un generador de numeros criptograficos aleatorios:
+Cuando la app se abre por primera vez, se [genera una llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L54) usando un generador de números criptográficos aleatorios:
 
     TracerKey = RNG()
 
-Esta llave no va a ser compartida con ningun otro usuario de la app, pero sera usada para crear llaves diarias y horales.
+Esta llave no va a ser compartida con ningún otro usuario de la app, pero sera usada para crear llaves diarias y horales.
 
-Cada dia (UTC), [se deriva una nueva llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L80) de la `TracerKey` usando una funcion *SHA-256 HMAC*, en conjunto con la fecha actual (como una cadena de caracteres ISO 8601):
+Cada día (UTC), [se deriva una nueva llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L80) de la `TracerKey` usando una funcion *SHA-256 HMAC*, en conjunto con la fecha actual (como una cadena de caracteres ISO 8601):
 
     DailyKey = HMAC-SHA256(TracerKey, CurrentDate('YYYY-MM-DD'))
     
 La `TracerKey` original no puede ser derivada desde la `DailyKey`. 
 
-El identificador actual enviado por bluetooth [es derivado](CovidTracer/Models/Keys/DailyTracerKey.cs#L49) cada hora (UTC) de la llave del dia actual' y la hora actual. ya que las caracteristicas de BLE estan limitadas a 20 bytes, esta llave tambien es truncada:
+El identificador actual enviado por bluetooth [es derivado](CovidTracer/Models/Keys/DailyTracerKey.cs#L49) cada hora (UTC) de la llave del día actual y la hora actual. ya que las características de BLE están limitadas a 20 bytes, esta llave tambien es truncada:
 
     CurrentKey = TRUNCATE(HMAC-SHA256(DailyKey, CurrentTime('YYYY-MM-DDTHH'))
 
-Si un usuario se reporta a si mismo como positivo para SARS-CoV-2, todos los identificadores diarios usados/a ser usados durante el periodo infeccioso van a ser [compartidos con un servidor central](https://covid-tracer-backend.herokuapp.com/cases.json) (desde 5 dias antes de que aparescan los simtomas, hasta 11 dias despues). Otras instancias de la aplicacion pueden despues derivar llaves generadas horalmente durante el periodo infeccioso, y potencialmente coincidir con cualquier contacto que allan tenido previamente. 
+Si un usuario se reporta a si mismo como positivo para SARS-CoV-2, todos los identificadores diarios usados/a ser usados durante el periodo infeccioso van a ser [compartidos con un servidor central](https://covid-tracer-backend.herokuapp.com/cases.json) (desde 5 días antes de que aparescan los síntomas, hasta 11 días despues). Otras instancias de la aplicación pueden despues derivar llaves generadas horalmente durante el periodo infeccioso, y potencialmente coincidir con cualquier contacto que allan tenido previamente. 
 
 Medidas adicionales para mejorar la privacidad:
 
-- Las llaves de rastreo de contactos son automaticamente removidas del dispositivo luego de 15 dias;
-- El backend retorna llaves diarias en orden alfabetico, y solo las publica cada 12 horas. Esto hace que sea mas dificil asociar multiples llaves diarias con un solo usuario;
+- Las llaves de rastreo de contactos son automáticamente removidas del dispositivo luego de 15 días;
+- El backend retorna llaves diarias en orden alfabético, y solo las publica cada 12 horas. Esto hace que sea mas difícil asociar múltiples llaves diarias con un solo usuario;
 - El backend no publica llaves diarias de fechas futuras, y las aplicacionessolo coinciden contactos que ocurrieron en el dia asociado con la llave. Esto evita la impersonificacion del usuario; 
-- La calidad de la señal Bluetooth es usada para evaluar la proximidad de dispositivos cercanos. El algoritmo solo para registrar identificadores de dispositivos ubicados en la misma habitacion;
+- La calidad de la señal Bluetooth es usada para evaluar la proximidad de dispositivos cercanos. El algoritmo solo para registrar identificadores de dispositivos ubicados en la misma habitación;
 - El backend implementa limites de ratio estrictos en el reportaje;
-- Toda la communicacion con el backend se hace mediante HTTPS;
+- Toda la comunicación con el backend se hace mediante HTTPS;
 - El backend [esta disponible](https://github.com/RaphaelJ/covid-tracer-backend) como software libre y gratuito.
 
-Opciones mas avanzadas de diagnostico e informacion de debugging se puede obtener diractamente desde la aplicacion haciendo click 10 veces en la "tracer key ID" en la pagina de *Acerca de*.
+Opciones mas avanzadas de diagnostico e información de debugging se puede obtener directamente desde la aplicación haciendo click 10 veces en la "tracer key ID" en la pagina de *Acerca de*.
 
 ## Agradecimientos especiales
 
-Estos usuarios proveyeron la traduccion en los siguientes lenguajes:
+Estos usuarios proveyeron la traducción en los siguientes lenguajes:
 
 - Croatian/Hrvatski: [micimacahaca](https://old.reddit.com/user/micimacahaca);
 - Holandés: [vlammuh](https://www.reddit.com/user/vlammuh) y [bavoceulemans](https://github.com/bavoceulemans);

--- a/README_ESP.md
+++ b/README_ESP.md
@@ -52,21 +52,21 @@ The app constantly broadcasts a unique 20 bytes identifier over Bluetooth Low En
 
 If the user ever reports her/himself as positive to SARS-CoV-2, the hourly-generated identifiers coresponding to the infectious period (16 days) are anonymously published on a central server. Other app users can then compare these identifiers with the ones they recorded over the past few days.
 
-### Details
+### Detalles
 
-When the app is started for the first time, a [256 bits key is generated](CovidTracer/Models/Keys/TracerKey.cs#L54) using a cryptographic random number generator:
+Cuando la app se abre por primera vez, se [genera una llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L54) usando un generador de numeros criptograficos aleatorios:
 
     TracerKey = RNG()
 
-This key will not be shared with other app users but will be used to derivate daily and hourly keys.
+Esta llave no va a ser compartida con ningun otro usuario de la app, pero sera usada para crear llaves diarias y horales.
 
-Every (UTC) day, [a new 256 bits key is derived](CovidTracer/Models/Keys/TracerKey.cs#L80) from the `TracerKey` using a *SHA-256 HMAC* function, together with the current date (as an ISO 8601 string):
+Cada dia (UTC), [se deriva una nueva llave de 256 bits](CovidTracer/Models/Keys/TracerKey.cs#L80) de la `TracerKey` usando una funcion *SHA-256 HMAC*, en conjunto con la fecha actual (como una cadena de caracteres ISO 8601):
 
     DailyKey = HMAC-SHA256(TracerKey, CurrentDate('YYYY-MM-DD'))
     
-The original `TracerKey` can not be derived back from the `DailyKey`. 
+La `TracerKey` original no puede ser derivada desde la `DailyKey`. 
 
-The actual indentifier broadcasted over Bluetooth [is derived](CovidTracer/Models/Keys/DailyTracerKey.cs#L49) every (UTC) hour from the current day' key and current time. As Bluetooth Low Energy characteristics are limited to 20 bytes, this key is also truncated:
+El identificador actual enviado por bluetooth [es derivado](CovidTracer/Models/Keys/DailyTracerKey.cs#L49) cada hora (UTC) de la llave del dia actual' y la hora actual. ya que las caracteristicas de BLE estan limitadas a 20 bytes, esta llave tambien es truncada:
 
     CurrentKey = TRUNCATE(HMAC-SHA256(DailyKey, CurrentTime('YYYY-MM-DDTHH'))
 

--- a/README_ESP.md
+++ b/README_ESP.md
@@ -1,0 +1,94 @@
+﻿# CovidTracer
+
+CovidTracer es una aplicacion de rastreo de contacto **decentralisada** y **anonima** diseñada para la pandema actual del COVID-19.
+
+CovidTracer le notifica al usuario de cualquier contacto cercano con otros usuarios diagnosticados con COVID-19. 
+
+![Android](screenshots/screenshot-android.png) ![iOS](screenshots/screenshot-ios.png)
+
+CovidTracer usa Bluetooth y tecnicas criptograficas para proteger la privacidad del usuario. Los usuarios de la app no comparten informacion personal. Jamas se mantiene ningun registro de la ubicacion GPS.
+
+CovidTracer sigue las [recomendaciones de rastreo de contacto](https://www.eff.org/deeplinks/2020/04/challenge-proximity-apps-covid-19-contact-tracing) de la Electronic Frontier Foundation.
+
+CovidTracer is a software libre y gratuito(GPLv3).
+
+## Descarga e Instalacion
+
+Google y Apple [actualmente no permiten](https://www.theverge.com/2020/3/5/21167102/apple-google-coronavirus-iphone-apps-android-misinformation-reject-ban) ninguna aplicacion relacionada al coronavirus que no este relacionada con organizaciones de la salud reconozidas o gobiernos o sus tiendas. La aplicacion aun se puede instalar por medios alternativos:
+
+En **Android**, se puede descargar un APK instalable [aqui](https://github.com/RaphaelJ/covid-tracer/releases/download/v0.1.1/covidtracer_0.1.1.apk).
+
+En **iOS**, solo los desarrolladores registrados de Apple pueden compilar, firmar e instalar la app en sus iPhones. Esto se puede realizar mediante la clonacion del repositorio y mediante el uso de [Visual Studio para macOS](https://visualstudio.microsoft.com/vs/mac/). La app de iOS no soporta todas las caracteristicas aun. 
+
+## Frequently asked questions
+
+- **What are the privacy features of CovidTracer?**
+CovidTracer uses cryptographic techniques similar to those used by e-commerce and crypto currencies. These provide an high degree of privacy that prevents anyone to associate the use of the app with any of your personal data (location, name...).
+
+- **When should I use CovidTracer?**
+For maximum efficiency, opens the app or let it run in background when you interact with people external to your household (transports, office, grocery stores, outdoor activities...).
+
+- **What to do when the app detects a high-risk contact?**
+Please inform your general practitioner as soon as possible about the high-risk contact the app detected. The app does not notify any health or governmental organization on positive match.
+
+- **Why is the Android application requesting access to my location?**
+Android app must [request the location permission](https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions) to access some Bluetooth features, such as scanning. CovidTracer does not use or record your location.
+
+- **How can I remove any data recorded by the app?**
+Un-installing the application from your smartphone will delete all data the app recorded. If you ever reported yourself as a positive case, some (anonymous) data associated to your infectious perdiod will still be availaible to other app users.
+
+- **I like the project, how can I help?** 
+I am developping the app as a personal side-project with few resources. I would very much welcome any help.
+    - If you speak a foreign language, you can help by translating [one of the localization files](CovidTracer/Resx/);
+    - If you have some skills in computer science and/or cryptography, do not hesitate to read the technical details and to provide feedback;
+    - If you are a graphic and/or UX designer, you can help by improving some of the UI components of the application (onboarding, icons...);
+    - Creating an anonymous and (moslty) distributed contact-tracing application is possible. Please pressure your local gouvernment to take privacy into account if they are developing their own contact tracing systems.
+
+## Technical details
+
+### Overview
+
+The app constantly broadcasts a unique 20 bytes identifier over Bluetooth Low Energy to nearby devices. This identifier is randonly generated (thus can not be associated with personal information) and is renewed every hour (preventing long-term tracking). Nearby CovidTracer users constantly record these identifiers in a database located on their devices. These identifiers are not shared with any central server or entity.
+
+If the user ever reports her/himself as positive to SARS-CoV-2, the hourly-generated identifiers coresponding to the infectious period (16 days) are anonymously published on a central server. Other app users can then compare these identifiers with the ones they recorded over the past few days.
+
+### Details
+
+When the app is started for the first time, a [256 bits key is generated](CovidTracer/Models/Keys/TracerKey.cs#L54) using a cryptographic random number generator:
+
+    TracerKey = RNG()
+
+This key will not be shared with other app users but will be used to derivate daily and hourly keys.
+
+Every (UTC) day, [a new 256 bits key is derived](CovidTracer/Models/Keys/TracerKey.cs#L80) from the `TracerKey` using a *SHA-256 HMAC* function, together with the current date (as an ISO 8601 string):
+
+    DailyKey = HMAC-SHA256(TracerKey, CurrentDate('YYYY-MM-DD'))
+    
+The original `TracerKey` can not be derived back from the `DailyKey`. 
+
+The actual indentifier broadcasted over Bluetooth [is derived](CovidTracer/Models/Keys/DailyTracerKey.cs#L49) every (UTC) hour from the current day' key and current time. As Bluetooth Low Energy characteristics are limited to 20 bytes, this key is also truncated:
+
+    CurrentKey = TRUNCATE(HMAC-SHA256(DailyKey, CurrentTime('YYYY-MM-DDTHH'))
+
+If a user reports her/himself positive to SARS-CoV-2, all the generated daily identifiers used/to be used during the infectious period will be [shared with a central server](https://covid-tracer-backend.herokuapp.com/cases.json) (from 5 days before the symptoms onset, up to 11 days after). Other application instances can then derivate all hourly generated keys during the infectious period, and potentially match then with any contact they previously had. 
+
+Additional measures have been taken to increase privacy:
+
+- Contact tracing keys are automatically removed from the phone after 15 days;
+- The backend returns daily keys in alphabetical order, and only publishes them every 12 hours. This makes it harder to associate multiple daily keys with a single user;
+- The backend does not publish daily keys of future dates, and the apps only match contacts that occured on the day associated with the key. This prevents user impersonification; 
+- Bluetooth signal quality is used to evaluate proximity of nearby devices. The algorithm is calibrated to only record identifiers of devices located in the same room;
+- The backend implements strict rate-limiting on reporting;
+- All communication with the backend is done over HTTPS;
+- The backend [is availaible](https://github.com/RaphaelJ/covid-tracer-backend) as a free and opensource software.
+
+More advanced diagnostic and debugging information can be obtained directly in the application by tapping 10 times on the tracer key ID on the *About* page.
+
+## Special thanks
+
+These users provided the translation in the following languages:
+
+- Croatian/Hrvatski: [micimacahaca](https://old.reddit.com/user/micimacahaca);
+- Dutch: [vlammuh](https://www.reddit.com/user/vlammuh) and [bavoceulemans](https://github.com/bavoceulemans);
+- Brazilian/Portuguese: [Raphael Salomao](https://github.com/raphaelsalomao3);
+- Spanish: [Barraguesh](https://github.com/Barraguesh).

--- a/README_ESP.md
+++ b/README_ESP.md
@@ -8,7 +8,7 @@ CovidTracer le notifica al usuario de cualquier contacto cercano con otros usuar
 
 CovidTracer usa Bluetooth y tecnicas criptograficas para proteger la privacidad del usuario. Los usuarios de la app no comparten informacion personal. Jamas se mantiene ningun registro de la ubicacion GPS.
 
-CovidTracer sigue las [recomendaciones de rastreo de contacto](https://www.eff.org/deeplinks/2020/04/challenge-proximity-apps-covid-19-contact-tracing) de la Electronic Frontier Foundation.
+CovidTracer sigue las [recomendaciones de rastreo de contacto](https://www.eff.org/deeplinks/2020/04/challenge-proximity-apps-covid-19-contacto-tracing) de la Electronic Frontier Foundation.
 
 CovidTracer is a software libre y gratuito(GPLv3).
 
@@ -20,31 +20,31 @@ En **Android**, se puede descargar un APK instalable [aqui](https://github.com/R
 
 En **iOS**, solo los desarrolladores registrados de Apple pueden compilar, firmar e instalar la app en sus iPhones. Esto se puede realizar mediante la clonacion del repositorio y mediante el uso de [Visual Studio para macOS](https://visualstudio.microsoft.com/vs/mac/). La app de iOS no soporta todas las caracteristicas aun. 
 
-## Frequently asked questions
+## Preguntas Frecuentes
 
-- **What are the privacy features of CovidTracer?**
-CovidTracer uses cryptographic techniques similar to those used by e-commerce and crypto currencies. These provide an high degree of privacy that prevents anyone to associate the use of the app with any of your personal data (location, name...).
+- **Cuales son las capacidades de privacidad en CovidTracer?**
+CovidTracer usa tecnicas criptograficas similares a las usadas por e-commerce y crypto-monedas. Estas proveen altos niveles de privacidad que evitan que cualquiera asocie el uso de esta app con cualquiera de tus datos personales (ubicacion, nombre...).
 
-- **When should I use CovidTracer?**
-For maximum efficiency, opens the app or let it run in background when you interact with people external to your household (transports, office, grocery stores, outdoor activities...).
+- **Cuando deberia usar CovidTracer?**
+Para eficiencia maxima, abre la app y dejala ejecutarse en 2do plano cuando interactuas con personas ajenas a tu hogas (transportes, officina, tiendas, actividades en el exterior...).
 
-- **What to do when the app detects a high-risk contact?**
-Please inform your general practitioner as soon as possible about the high-risk contact the app detected. The app does not notify any health or governmental organization on positive match.
+- **Que hago cuando la aplicacion detecta un contacto de alto riesgo?**
+Por favor informa a la autoridad competente tan pronto como se detecte el contacto de alto-riesgo. La app no notifica a ninguna organizacion gubernamental ni de la salud sobre el caso positivo.
 
-- **Why is the Android application requesting access to my location?**
-Android app must [request the location permission](https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions) to access some Bluetooth features, such as scanning. CovidTracer does not use or record your location.
+- **Por que pide acceso a la ubicacion la aplicacion de Android?**
+La aplicacion de Android debe [pedir el permiso de ubicacion](https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions) para acceder a algunas capacidades bluetooth, como el escaneo. CovidTracer no utiliza ni registra.
 
-- **How can I remove any data recorded by the app?**
-Un-installing the application from your smartphone will delete all data the app recorded. If you ever reported yourself as a positive case, some (anonymous) data associated to your infectious perdiod will still be availaible to other app users.
+- **Como puedo remover cualquier informacion recolectada por la app?**
+Des-instalar la aplicacion de tu smartphone va a borrar toda la informacion que recolecto la aplicacion. Si alguna vez te reportaste a ti mismo como un caso positivo, algunos datos (anonimos) asociados a tu periodo infeccioso aun van a estar disponibles a otros usuarios de la app.
 
-- **I like the project, how can I help?** 
-I am developping the app as a personal side-project with few resources. I would very much welcome any help.
-    - If you speak a foreign language, you can help by translating [one of the localization files](CovidTracer/Resx/);
-    - If you have some skills in computer science and/or cryptography, do not hesitate to read the technical details and to provide feedback;
-    - If you are a graphic and/or UX designer, you can help by improving some of the UI components of the application (onboarding, icons...);
-    - Creating an anonymous and (moslty) distributed contact-tracing application is possible. Please pressure your local gouvernment to take privacy into account if they are developing their own contact tracing systems.
+- **Me gusta el proyecto. Como puedo ayudar?** 
+Estoy desarrollando la aplicacion como un proyecto personalcon pocos recorsos. Recibiria con mucho gusto cualquier ayuda.
+    - Si hablas un lenguaje extrangero, puedes ayudar traduciendo [uno de los archivos de localizacion](CovidTracer/Resx/);
+    - Si tienes habilidades en ciencia computacional y/o cryptografia, no dudes en leer los detalles tecnicos y en proveer feedback;
+    - Si eres un diseñador grafico o de UX, puedes ayudar a mejorar algunos de los componentes de la UI de la aplicacion (onboarding, iconos...);
+    - Crear una applicacion (mayormente) distribuida de rastreo de contacto es posible. Por favor presiona a tu gobierno local a tener la privacidad en cuenta si estan desarrollando sus propios sistemas de rastreo de contactos.
 
-## Technical details
+## Detalles tecnicos
 
 ### Overview
 
@@ -70,11 +70,11 @@ The actual indentifier broadcasted over Bluetooth [is derived](CovidTracer/Model
 
     CurrentKey = TRUNCATE(HMAC-SHA256(DailyKey, CurrentTime('YYYY-MM-DDTHH'))
 
-If a user reports her/himself positive to SARS-CoV-2, all the generated daily identifiers used/to be used during the infectious period will be [shared with a central server](https://covid-tracer-backend.herokuapp.com/cases.json) (from 5 days before the symptoms onset, up to 11 days after). Other application instances can then derivate all hourly generated keys during the infectious period, and potentially match then with any contact they previously had. 
+If a user reports her/himself positive to SARS-CoV-2, all the generated daily identifiers used/to be used during the infectious period will be [shared with a central server](https://covid-tracer-backend.herokuapp.com/cases.json) (from 5 days before the symptoms onset, up to 11 days after). Other application instances can then derivate all hourly generated keys during the infectious period, and potentially match then with any contacto they previously had. 
 
 Additional measures have been taken to increase privacy:
 
-- Contact tracing keys are automatically removed from the phone after 15 days;
+- contacto tracing keys are automatically removed from the phone after 15 days;
 - The backend returns daily keys in alphabetical order, and only publishes them every 12 hours. This makes it harder to associate multiple daily keys with a single user;
 - The backend does not publish daily keys of future dates, and the apps only match contacts that occured on the day associated with the key. This prevents user impersonification; 
 - Bluetooth signal quality is used to evaluate proximity of nearby devices. The algorithm is calibrated to only record identifiers of devices located in the same room;


### PR DESCRIPTION
The translation of the README.md is in the file "README_ESP.md"
I added a reference to this file at the beggining of the original README.md: "Click aqui para leer la version en ESPAÑOL", wich translates to "Click here to read the SPANISH version".
I also added myself to the translators section at the end.